### PR TITLE
Eliminate non-singularity checks in lattice code

### DIFF
--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -10,10 +10,6 @@ Represent the real lattices and the reciprocal lattices.
 abstract type AbstractLattice{T} <: AbstractMatrix{T} end
 struct Lattice{T} <: AbstractLattice{T}
     data::MMatrix{3,3,T,9}
-    function Lattice{T}(data) where {T}
-        @assert !iszero(det3x3(data)) "lattice is singular!"
-        return new(data)
-    end
 end
 """
     Lattice(data::AbstractMatrix)
@@ -130,9 +126,3 @@ Base.similar(
     bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{Lattice}}, ::Type{S}
 ) where {S} = similar(Lattice{S}, axes(bc))
 Lattice{S}(::UndefInitializer, dims) where {S} = Lattice(Array{S,length(dims)}(undef, dims))
-
-# `LinearAlgebra.det` is much slower and more inaccurate than my simple `det3x3`.
-function det3x3(matrix)
-    a, d, g, b, e, h, c, f, i = matrix  # Only works for 3×3 matrices
-    return a * e * i + b * f * g + c * d * h - c * e * g - b * d * i - a * f * h
-end

--- a/test/lattice.jl
+++ b/test/lattice.jl
@@ -10,12 +10,6 @@ using Unitful, UnitfulAtomic
             3.4 6.7 9.1
         ]
         @test Lattice(mat) == Lattice(MMatrix{3,3}(mat))
-        # Singular matrix
-        @test_throws AssertionError Lattice([
-            1 2 3
-            4 5 6
-            7 8 9
-        ])
         # Rectangular matrix
         @test_throws DimensionMismatch Lattice([
             1 2


### PR DESCRIPTION
- Eliminate checks for non-singular lattice matrix
- Remove redundant custom determinant function for 3x3 matrices