### PR TITLE
Deprecate `AbstractLattice` subtyping from `AbstractMatrix`

### DIFF
--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -20,7 +20,6 @@ Pages = ["public.md"]
 ```@docs
 Lattice
 basisvectors(::Lattice)
-eachbasisvector(::Lattice)
 ```
 
 ### Reciprocal lattices
@@ -28,7 +27,6 @@ eachbasisvector(::Lattice)
 ```@docs
 ReciprocalLattice
 basisvectors(::ReciprocalLattice)
-eachbasisvector(::ReciprocalLattice)
 reciprocal
 ```
 

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -1,7 +1,7 @@
 using StaticArrays: MMatrix, SDiagonal
 using StructEquality: @struct_hash_equal_isequal_isapprox
 
-export Lattice, eachbasisvector, basisvectors
+export Lattice, basisvectors
 
 """
     AbstractLattice{T} <: AbstractMatrix{T}
@@ -114,14 +114,8 @@ end
 
 Get the three basis vectors from a lattice.
 """
-basisvectors(lattice::Lattice) = Tuple(eachcol(lattice))
-
-"""
-    eachbasisvector(lattice::Lattice)
-
-Iterate over the three basis vectors of a lattice.
-"""
-eachbasisvector(lattice::Lattice) = eachcol(lattice)
+basisvectors(lattice::Lattice) =
+    lattice[begin:(begin + 2)], lattice[(begin + 3):(begin + 5)], lattice[(begin + 6):end]
 
 # See https://github.com/JuliaLang/julia/blob/v1.10.0-beta1/stdlib/LinearAlgebra/src/uniformscaling.jl#L130-L131
 Base.one(::Type{Lattice{T}}) where {T} = Lattice(SDiagonal(one(T), one(T), one(T)))

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -126,6 +126,10 @@ Base.oneunit(::Type{Lattice{T}}) where {T} =
     Lattice(SDiagonal(oneunit(T), oneunit(T), oneunit(T)))
 Base.oneunit(lattice::Lattice) = oneunit(typeof(lattice))
 
+# See https://github.com/JuliaLang/julia/blob/v1.10.0-beta1/stdlib/LinearAlgebra/src/uniformscaling.jl#L134-L135
+Base.zero(::Type{Lattice{T}}) where {T} = Lattice(zeros(T, 3, 3))
+Base.zero(lattice::Lattice) = zero(typeof(lattice))
+
 # Similar to https://github.com/JuliaCollections/IterTools.jl/blob/0ecaa88/src/IterTools.jl#L1028-L1032
 Base.iterate(iter::Lattice, state=1) = iterate(parent(iter), state)
 

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -157,4 +157,9 @@ Base.:*(x::Number, lattice::Lattice) = lattice * x
 Base.:/(lattice::Lattice, x::Number) = Lattice(parent(lattice) / x)
 
 Base.:+(lattice::Lattice) = lattice
+Base.:+(lattice::Lattice, x::Number) = Lattice(parent(lattice) .+ x)
+Base.:+(x::Number, lattice::Lattice) = lattice + x
+
 Base.:-(lattice::Lattice) = -one(eltype(lattice)) * lattice
+Base.:-(lattice::Lattice, x::Number) = Lattice(parent(lattice) .- x)
+Base.:-(x::Number, lattice::Lattice) = -lattice + x

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -1,4 +1,5 @@
 using StaticArrays: MMatrix, SDiagonal
+using StructEquality: @struct_hash_equal_isequal_isapprox
 
 export Lattice, eachbasisvector, basisvectors
 
@@ -29,7 +30,7 @@ julia> Lattice([
  3.4  6.7  9.1
 ```
 """
-mutable struct Lattice{T} <: AbstractLattice{T}
+@struct_hash_equal_isequal_isapprox struct Lattice{T} <: AbstractLattice{T}
     data::MMatrix{3,3,T,9}
 end
 Lattice(data::AbstractMatrix) = Lattice(MMatrix{3,3}(data))

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -7,7 +7,7 @@ export Lattice, eachbasisvector, basisvectors
 
 Represent the real lattices and the reciprocal lattices.
 """
-abstract type AbstractLattice{T} <: AbstractMatrix{T} end
+abstract type AbstractLattice{T} end
 """
     Lattice(data::AbstractMatrix)
 

--- a/src/reciprocal.jl
+++ b/src/reciprocal.jl
@@ -15,7 +15,7 @@ Construct a `ReciprocalLattice` from a matrix.
 !!! warning
     Avoid using this constructor directly. Use `reciprocal` instead.
 """
-struct ReciprocalLattice{T} <: AbstractLattice{T}
+@struct_hash_equal_isequal_isapprox struct ReciprocalLattice{T} <: AbstractLattice{T}
     data::MMatrix{3,3,T,9}
 end
 ReciprocalLattice(data::AbstractMatrix) = ReciprocalLattice(MMatrix{3,3}(data))

--- a/src/reciprocal.jl
+++ b/src/reciprocal.jl
@@ -25,14 +25,8 @@ ReciprocalLattice(data::AbstractMatrix) = ReciprocalLattice(MMatrix{3,3}(data))
 
 Get the three basis vectors from a reciprocal lattice.
 """
-basisvectors(lattice::ReciprocalLattice) = Tuple(eachbasisvector(lattice))
-
-"""
-    eachbasisvector(lattice::ReciprocalLattice)
-
-Iterate over the three basis vectors of a reciprocal lattice.
-"""
-eachbasisvector(lattice::ReciprocalLattice) = eachcol(lattice)
+basisvectors(lattice::ReciprocalLattice) =
+    lattice[begin:(begin + 2)], lattice[(begin + 3):(begin + 5)], lattice[(begin + 6):end]
 
 """
     reciprocal(lattice::Lattice)
@@ -47,7 +41,7 @@ function reciprocal(lattice::Lattice)
 end
 function reciprocal(lattice::ReciprocalLattice)
     Ω⁻¹ = det(lattice.data)  # Cannot use `cellvolume`, it takes the absolute value!
-    𝐚⁻¹, 𝐛⁻¹, 𝐜⁻¹ = eachbasisvector(lattice)
+    𝐚⁻¹, 𝐛⁻¹, 𝐜⁻¹ = basisvectors(lattice)
     return inv(Ω⁻¹) * Lattice(hcat(cross(𝐛⁻¹, 𝐜⁻¹), cross(𝐜⁻¹, 𝐚⁻¹), cross(𝐚⁻¹, 𝐛⁻¹)))
 end
 

--- a/src/reciprocal.jl
+++ b/src/reciprocal.jl
@@ -1,7 +1,5 @@
 using LinearAlgebra: I, det, cross
 
-import Base: *, /
-
 export ReciprocalLattice, reciprocal, isreciprocal
 
 """
@@ -78,3 +76,12 @@ Base.getindex(lattice::ReciprocalLattice, i...) = getindex(parent(lattice), i...
 Base.firstindex(::ReciprocalLattice) = 1
 
 Base.lastindex(::ReciprocalLattice) = 9
+
+Base.:*(lattice::ReciprocalLattice, x::Number) = ReciprocalLattice(parent(lattice) * x)
+Base.:*(x::Number, lattice::ReciprocalLattice) = lattice * x
+
+Base.:/(lattice::ReciprocalLattice, x::Number) = ReciprocalLattice(parent(lattice) / x)
+
+Base.:+(lattice::ReciprocalLattice) = lattice
+
+Base.:-(lattice::ReciprocalLattice) = -one(eltype(lattice)) * lattice

--- a/src/reciprocal.jl
+++ b/src/reciprocal.jl
@@ -58,50 +58,23 @@ Base.oneunit(::Type{ReciprocalLattice{T}}) where {T} =
     ReciprocalLattice(MMatrix{3,3}(SDiagonal(oneunit(T), oneunit(T), oneunit(T))))
 Base.oneunit(lattice::ReciprocalLattice) = oneunit(typeof(lattice))
 
-Base.parent(lattice::ReciprocalLattice) = lattice.data
+# Similar to https://github.com/JuliaCollections/IterTools.jl/blob/0ecaa88/src/IterTools.jl#L1028-L1032
+Base.iterate(iter::ReciprocalLattice, state=1) = iterate(parent(iter), state)
+
+Base.IteratorSize(::Type{<:ReciprocalLattice}) = Base.HasShape{2}()
+
+Base.eltype(::Type{ReciprocalLattice{T}}) where {T} = T
+
+Base.length(::ReciprocalLattice) = 9
 
 Base.size(::ReciprocalLattice) = (3, 3)
+# See https://github.com/rafaqz/DimensionalData.jl/blob/bd28d08/src/array/array.jl#L74
+Base.size(lattice::ReciprocalLattice, dim) = size(parent(lattice), dim)  # Here, `parent(A)` is necessary to avoid `StackOverflowError`.
 
-Base.getindex(lattice::ReciprocalLattice, i::Int) = getindex(parent(lattice), i)
-Base.getindex(lattice::ReciprocalLattice, I...) = getindex(parent(lattice), I...)
+Base.parent(lattice::ReciprocalLattice) = lattice.data
 
-Base.setindex!(lattice::ReciprocalLattice, v, i::Int) = setindex!(parent(lattice), v, i)
-Base.setindex!(lattice::ReciprocalLattice, X, I...) = setindex!(parent(lattice), X, I...)
+Base.getindex(lattice::ReciprocalLattice, i...) = getindex(parent(lattice), i...)
 
-Base.IndexStyle(::Type{<:ReciprocalLattice}) = IndexLinear()
+Base.firstindex(::ReciprocalLattice) = 1
 
-# Customizing broadcasting
-# See https://github.com/JuliaArrays/StaticArraysCore.jl/blob/v1.4.2/src/StaticArraysCore.jl#L397-L398
-# and https://github.com/JuliaLang/julia/blob/v1.10.0-beta1/stdlib/LinearAlgebra/src/structuredbroadcast.jl#L7-L14
-struct ReciprocalLatticeStyle <: Broadcast.AbstractArrayStyle{2} end
-ReciprocalLatticeStyle(::Val{2}) = ReciprocalLatticeStyle()
-ReciprocalLatticeStyle(::Val{N}) where {N} = Broadcast.DefaultArrayStyle{N}()
-
-Base.BroadcastStyle(::Type{<:ReciprocalLattice}) = ReciprocalLatticeStyle()
-
-Base.similar(::Broadcast.Broadcasted{ReciprocalLatticeStyle}, ::Type{T}) where {T} =
-    similar(ReciprocalLattice{T}, 3, 3)
-# Override https://github.com/JuliaLang/julia/blob/v1.10.0-beta2/base/abstractarray.jl#L839
-function Base.similar(lattice::ReciprocalLattice, ::Type{T}, dims::Dims) where {T}
-    if dims == size(lattice)
-        return ReciprocalLattice(similar(Matrix{T}, dims))
-    else
-        throw(ArgumentError("invalid dims `$dims` for `Lattice`!"))
-    end
-end
-# Override https://github.com/JuliaLang/julia/blob/v1.10.0-beta1/base/abstractarray.jl#L874
-function Base.similar(::Type{ReciprocalLattice{T}}, dims::Dims) where {T}
-    if dims == (3, 3)
-        return ReciprocalLattice(similar(Matrix{T}, dims))
-    else
-        throw(ArgumentError("invalid dims `$dims` for `ReciprocalLattice`!"))
-    end
-end
-
-for op in (:*, :/)
-    for S in (:Lattice, :ReciprocalLattice)
-        for T in (:Lattice, :ReciprocalLattice)
-            @eval $op(::$S, ::$T) = error("undefined operation!")
-        end
-    end
-end
+Base.lastindex(::ReciprocalLattice) = 9

--- a/test/lattice.jl
+++ b/test/lattice.jl
@@ -1,4 +1,4 @@
-using CrystallographyCore: Lattice, basisvectors, eachbasisvector
+using CrystallographyCore: Lattice, basisvectors
 using StaticArrays: MMatrix
 using Unitful, UnitfulAtomic
 
@@ -13,7 +13,7 @@ using Unitful, UnitfulAtomic
         @test Lattice(mat) == Lattice(MMatrix{3,3}(mat))
         @test basisvectors(Lattice(mat)) ==
             ([1.2, 2.3, 3.4], [4.5, 5.6, 6.7], [7.8, 8.9, 9.1])
-        @test all(eachbasisvector(Lattice(mat)) .== basisvectors(Lattice(mat)))
+        @test all(basisvectors(Lattice(mat)) .== basisvectors(Lattice(mat)))
         # Rectangular matrix
         @test_throws DimensionMismatch Lattice([
             1 2


### PR DESCRIPTION
Deprecate array & broadcasting interface for `AbstractLattice`