### PR TITLE
Use `StaticVectors.Values` to replace `StaticArrays.SVector` in `Cell`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.3.2"
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+StaticVectors = "20fadf95-9e3d-483c-97cd-cab2760e7998"
 StructEquality = "6ec83bb0-ed9f-11e9-3b4c-2b04cb4e219c"
 
 [compat]

--- a/src/cell.jl
+++ b/src/cell.jl
@@ -1,4 +1,5 @@
 using StaticArrays: SVector, FieldVector
+using StaticVectors: Values
 using StructEquality: @struct_hash_equal_isequal
 
 export ReducedCoordinates, CrystalCoordinates, Cell, natoms, atomtypes
@@ -13,8 +14,8 @@ const CrystalCoordinates = ReducedCoordinates
 abstract type AbstractCell end
 @struct_hash_equal_isequal struct Cell{N,L,P,T} <: AbstractCell
     lattice::Lattice{L}
-    positions::SVector{N,ReducedCoordinates{P}}
-    atoms::SVector{N,T}
+    positions::Values{N,ReducedCoordinates{P}}
+    atoms::Values{N,T}
 end
 """
     Cell(lattice, positions, atoms)


### PR DESCRIPTION
`SVector` is very slow for large number of atoms