### PR TITLE
Use `NoUnits` in `UnitfulLinearAlgebraExt`, directly `collect` is wrong

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ UnitfulLinearAlgebraExt = ["Unitful", "UnitfulLinearAlgebra"]
 [compat]
 StaticArrays = "1"
 StructEquality = "1, 2"
+UnitfulLinearAlgebra = "0.3.2"
 julia = "1"
 
 [extras]

--- a/ext/UnitfulLinearAlgebraExt.jl
+++ b/ext/UnitfulLinearAlgebraExt.jl
@@ -1,12 +1,16 @@
 module UnitfulLinearAlgebraExt
 
 using CrystallographyCore: Inverted, AbstractLattice
-using Unitful: AbstractQuantity
+using Unitful: AbstractQuantity, NoUnits
 using UnitfulLinearAlgebra: UnitfulMatrix
 
 # See https://github.com/ggebbie/UnitfulLinearAlgebra.jl/issues/92
 (inverted::Inverted{<:AbstractLattice{<:AbstractQuantity}})(
     cartesian::AbstractVector{<:AbstractQuantity}
-) = collect(UnitfulMatrix(parent(inverted.lattice)) \ UnitfulMatrix(collect(cartesian)))
+) = collect(
+    NoUnits.(
+        vec(UnitfulMatrix(parent(inverted.lattice)) \ UnitfulMatrix(collect(cartesian)))
+    ),
+)
 
 end


### PR DESCRIPTION
Before this, converting between different units may cause wrong results